### PR TITLE
basic example of edge compute service in tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,3 +14,8 @@ module "google" {
   source    = "./modules/google"
   site_name = var.site_name
 }
+
+#module "fastly-wasm" {
+#  source    = "./modules/fastly-wasm"
+#  site_name = var.site_name
+#}

--- a/modules/fastly-wasm/main.tf
+++ b/modules/fastly-wasm/main.tf
@@ -1,0 +1,24 @@
+resource "fastly_service_compute" "demo" {
+  name = "${var.site_name}-wasm"
+
+  domain {
+    name = "${var.site_name}.edgecompute.app"
+  }
+
+  package {
+    filename         = "..//globe/pkg/globe.tar.gz"
+    source_code_hash = filesha512("../globe/pkg/globe.tar.gz")
+  }
+
+  backend {
+    name              = "fastlyapi"
+    address           = "api.fastly.com"
+    override_host     = "api.fastly.com"
+    ssl_cert_hostname = "api.fastly.com"
+    ssl_sni_hostname  = "api.fastly.com"
+    port              = 443
+    use_ssl           = true
+  }
+
+  force_destroy = true
+}

--- a/modules/fastly-wasm/provider.tf
+++ b/modules/fastly-wasm/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+}

--- a/modules/fastly-wasm/variables.tf
+++ b/modules/fastly-wasm/variables.tf
@@ -1,0 +1,3 @@
+variable "site_name" {
+  type = string
+}


### PR DESCRIPTION
its commented out by default because its hardcoded to deploy an edgecompute app i've built in a sibling directory, so will break for anyone else.  next step is to abstract it.