### PR TITLE
better link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 ## pre-reqs
 - a fastly account (with `io_entitlement` and `rate_limiting` feature flags)
-- an api key from that account
-- the fastly cli installed and configured with the key
-`fastly whoami`
+- the fastly cli
+- two api tokens from that account
+-- one with global api access and engineer or higher permission (for the cli)
+-- a second with read-only access and user or higher permission (for the edgeapp)
 - a sigsci account (corp)
 - an api key from that corp
 - a GCP account
@@ -20,17 +21,19 @@
 - jq
 
 ## howto
+### first time setup
 - clone this repo and cd into it
+- `terraform init`
 - `cp .env.example .env`
 - edit `.env` and populate the three `SIGSCI_` variables
 - `source .env`
-- `terraform init`
-- `terraform apply`
 - generate a read-only fastly api token and put it in `./edgeapp/.secret`
-- `./bin/secrets-apply.sh`
+### test loop
+- `source bin/secrets-apply.sh`
+- `terraform apply`
 - do your thing
-- `./bin/secrets-destroy.sh`
 - `terraform destroy`
+- `./bin/secrets-destroy.sh`
 
 ## wishlist
 - integrate dcorbett's sqli demo

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - `terraform init`
 - `cp .env.example .env`
 - edit `.env` and populate the three `SIGSCI_` variables
-- generate a read-only fastly api token and put it in `./edgeapp/.secret`
+- put the read-only api token in `./edgeapp/.secret`
 ### test loop
 - `source .env`
 - `source bin/secrets-apply.sh`

--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
 
 ## pre-reqs
 - a fastly account (with `io_entitlement` and `rate_limiting` feature flags)
-- the fastly cli
-- two api tokens from that account
--- one with global api access and engineer or higher permission (for the cli)
--- a second with read-only access and user or higher permission (for the edgeapp)
+- the fastly cli, configured with an api token with engineer or higher permission
+- another api token with read-only access and user or higher permission (for the edgeapp)
 - a sigsci account (corp)
 - an api key from that corp
 - a GCP account

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 - `terraform init`
 - `cp .env.example .env`
 - edit `.env` and populate the three `SIGSCI_` variables
-- `source .env`
 - generate a read-only fastly api token and put it in `./edgeapp/.secret`
 ### test loop
+- `source .env`
 - `source bin/secrets-apply.sh`
 - `terraform apply`
 - do your thing

--- a/bin/secrets-apply.sh
+++ b/bin/secrets-apply.sh
@@ -1,7 +1,2 @@
-source .env
-
-SERVICE_ID="$(fastly service describe --service-name=${TF_VAR_site_name}-wasm -j | jq '.ID' -r)"
-STORE_ID="$(fastly secret-store create --name=secrets -j | jq '.id' -r)"
-cat edgeapp/.secrets | fastly secret-store-entry create --store-id=${STORE_ID} --name=fastly-key --stdin
-fastly resource-link create -r ${STORE_ID} -s ${SERVICE_ID} --version=active --autoclone
-fastly service-version activate --service-id=${SERVICE_ID} --version=latest
+export TF_VAR_store_id="$(fastly secret-store create --name=secrets -j | jq '.id' -r)"
+cat edgeapp/.secrets | fastly secret-store-entry create --store-id=${TF_VAR_store_id} --name=fastly-key --stdin

--- a/bin/secrets-destroy.sh
+++ b/bin/secrets-destroy.sh
@@ -1,7 +1,2 @@
-source .env
-
-LINK_ID=$(fastly resource-link list --service-name=${TF_VAR_site_name}-wasm --version active -j | jq '.[0].id' -r)
-fastly resource-link delete --id=${LINK_ID} --version=latest --service-name=${TF_VAR_site_name}-wasm --autoclone
-fastly service-version activate --service-name=${TF_VAR_site_name}-wasm --version=latest
 STORE_ID=$(fastly secret-store list | grep secrets | awk '{print $2}')
 fastly secret-store delete --store-id=${STORE_ID}

--- a/main.tf
+++ b/main.tf
@@ -138,5 +138,10 @@ resource "fastly_service_compute" "demo" {
     use_ssl           = true
   }
 
+  resource_link {
+    name = "secrets"
+    resource_id = var.store_id
+  }
+
   force_destroy = true
 }

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "fastly_service_compute" "demo" {
   }
 
   resource_link {
-    name = "secrets"
+    name        = "secrets"
     resource_id = var.store_id
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
 variable "site_name" {
   type = string
 }
+
+variable "store_id" {
+  type = string
+}


### PR DESCRIPTION
while secret-store is not yet supported in TF, I didn't realize resource links already were (because of config-store).  this PR refactors the tf and shell to use the vcl service resources's native resource-link support instead of doing it 'manually' via the cli in the shell script.