### PR TITLE
make magento, puppeteer and randomhack optional

### DIFF
--- a/magento.tf
+++ b/magento.tf
@@ -3,8 +3,7 @@
 #######################################################################
 
 resource "terraform_data" "magento_setup" {
-  # wait for the waf to be done so the magento plugin's vcl activation doesn't step on it
-  depends_on = [sigsci_edge_deployment_service.ngwaf_edge_demo_link]
+  count = var.magento == true ? 1 : 0
 
   connection {
     type        = "ssh"

--- a/puppeteer.tf
+++ b/puppeteer.tf
@@ -1,4 +1,5 @@
 resource "google_compute_instance" "puppeteer" {
+  count                     = var.puppeteer == true ? 1 : 0
   name                      = "${var.site_name}-puppeteer"
   machine_type              = "c3-standard-4"
   depends_on                = [fastly_service_vcl.demo_service, terraform_data.magento_setup]

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,8 +1,11 @@
 site_name        = ""
 fastly_api_key   = ""
-magento_pub_key  = ""
-magento_priv_key = ""
 sigsci_corp      = ""
 sigsci_email     = ""
 sigsci_token     = ""
 google_project   = ""
+magento          = false
+magento_pub_key  = ""
+magento_priv_key = ""
+puppeteer        = false
+randomhack       = false

--- a/variables.tf
+++ b/variables.tf
@@ -2,26 +2,8 @@ variable "site_name" {
   type = string
 }
 
-variable "magento_pub_key" {
-  type = string
-}
-
-variable "magento_priv_key" {
-  type = string
-}
-
 variable "fastly_api_key" {
   type = string
-}
-
-variable "ssh_pub_key" {
-  type    = string
-  default = "~/.ssh/id_rsa.pub"
-}
-
-variable "ssh_priv_key" {
-  type    = string
-  default = "~/.ssh/id_rsa"
 }
 
 variable "sigsci_corp" {
@@ -50,7 +32,32 @@ variable "google_zone" {
   default = "us-east1-b"
 }
 
+variable "ssh_pub_key" {
+  type    = string
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "ssh_priv_key" {
+  type    = string
+  default = "~/.ssh/id_rsa"
+}
+
+variable "magento" {
+  type = bool
+}
+
+variable "magento_pub_key" {
+  type = string
+}
+
+variable "magento_priv_key" {
+  type = string
+}
+
+variable "puppeteer" {
+  type = bool
+}
+
 variable "randomhack" {
-  type    = bool
-  default = false
+  type = bool
 }


### PR DESCRIPTION
well randomhack already is, applying the same boolean-as-count trick to magento and puppeteer

also sorted the variables files to group better and be consistent