### PR TITLE
Race conditions

### DIFF
--- a/magento.sh
+++ b/magento.sh
@@ -1,5 +1,18 @@
-# mysql db and db user
-sudo apt -y install mysql-server
+#!/bin/bash
+set -xe
+
+# configure elasticsearch repo
+curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elastic.gpg
+echo "deb [signed-by=/usr/share/keyrings/elastic.gpg] https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-7.x.list
+sudo apt update
+
+# install packages
+sudo apt -y install php mysql-server elasticsearch php-mysql php-zip php-curl php-xml php-gd php-intl php-soap php-mbstring php-bcmath curl unzip
+
+# start elasticsearch
+sudo service elasticsearch start
+
+# setup db
 sudo mysql <<SQL
 CREATE DATABASE magento2;
 CREATE USER 'magento2'@'localhost' IDENTIFIED BY 'magento-test-pass';
@@ -8,15 +21,7 @@ FLUSH PRIVILEGES;
 SET GLOBAL innodb_buffer_pool_size=4294967296;
 SQL
 
-# install elasticsearch
-curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elastic.gpg
-echo "deb [signed-by=/usr/share/keyrings/elastic.gpg] https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-7.x.list
-sudo apt update
-sudo apt -y install elasticsearch
-sudo service elasticsearch start
-
 # configure webserver
-sudo apt -y install php php-zip php-curl php-xml php-gd php-intl php-mysql php-soap php-mbstring php-bcmath curl unzip
 sudo a2enmod rewrite
 sudo a2enmod expires
 
@@ -71,7 +76,6 @@ composer config http-basic.repo.magento.com ${repo_user} ${repo_pass}
 bin/magento sampledata:deploy
 find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
 find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
-bin/magento setup:upgrade
 
 # install the fastly module
 composer config repositories.fastly-magento2 git "https://github.com/fastly/fastly-magento2.git"

--- a/magento.sh
+++ b/magento.sh
@@ -76,6 +76,7 @@ composer config http-basic.repo.magento.com ${repo_user} ${repo_pass}
 bin/magento sampledata:deploy
 find var generated vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
 find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+bin/magento setup:upgrade
 
 # install the fastly module
 composer config repositories.fastly-magento2 git "https://github.com/fastly/fastly-magento2.git"

--- a/magento.tf
+++ b/magento.tf
@@ -12,6 +12,12 @@ resource "terraform_data" "magento_setup" {
     host        = google_compute_instance.demo_origin_instance.network_interface.0.access_config.0.nat_ip
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "until grep -q 'startup-script exit status 0' /var/log/syslog; do sleep 10; done",
+    ]
+  }
+
   provisioner "file" {
     source      = "magento.sh"
     destination = "magento.sh"

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 
 resource "google_compute_instance" "demo_origin_instance" {
   name         = "${var.site_name}-origin"
-  machine_type = "n2-standard-4"
+  machine_type = "n2-standard-8"
   zone         = "us-west1-a"
   tags         = ["https-server"]
 
@@ -25,5 +25,5 @@ resource "google_compute_instance" "demo_origin_instance" {
   }
 
   # configure a minmial secure webserver
-  metadata_startup_script = "apt update && apt -y install apache2 && a2enmod ssl && a2ensite default-ssl && a2dissite 000-default && service apache2 restart && usermod -a -G www-data ubuntu"
+  metadata_startup_script = "apt update && apt -y upgrade && apt -y install apache2 && a2enmod ssl && a2ensite default-ssl && a2dissite 000-default && service apache2 restart && usermod -a -G www-data ubuntu"
 }


### PR DESCRIPTION
if the vm metatadata script hasn't completed yet, the remote-exec connection would login as ubuntu before the user was put in the www-data group, which would in turn cause the chowns to fail.